### PR TITLE
Fix devise ominauth method deprecation warning

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -4,9 +4,9 @@
   | . Not you? 
   = link_to "Sign out", users_sign_out_path,:method => :delete
 - else
-  = link_to  user_omniauth_authorize_path(:google_oauth2) do
+  = link_to  user_google_oauth2_omniauth_authorize_path do
     .social-login-buttons
-      a.btn.btn-link-1.btn-link-1-google-plus href="#{url_for  user_omniauth_authorize_path(:google_oauth2)}" 
+      a.btn.btn-link-1.btn-link-1-google-plus href="#{url_for  user_google_oauth2_omniauth_authorize_path}"
         i.fa.fa-google-plus
           | &nbsp Login with Google
 


### PR DESCRIPTION
This fixes the warning from devise about `user_omniauth_authorize_path(:google_oauth2)` being deprecated.
