### PR TITLE
Fix OAuth environment variables names

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,6 @@
-GATE_OAUTH_SECRET=totally_secret
-GATE_OAUTH_CLIENT_KEY=totally_secret_client_key
+GATE_OAUTH_CLIENT_ID=totally_secret_client_id
+GATE_OAUTH_CLIENT_SECRET=totally_secret
 GATE_HOSTED_DOMAIN=gate.domain
 GATE_SERVER_URL=gate.server/url
 GATE_CONFIG_SECRET=gate_pw_secret
 GATE_EMAIL_DOMAIN=gate.domain
-GATE_OAUTH_API_KEY=totally_secret_api_key

--- a/README.md
+++ b/README.md
@@ -29,13 +29,12 @@ Gate is a Rails application, compatible with JRuby.
 * Setup 5 environment variables
 
 ```
-GATE_OAUTH_SECRET       - Your OAuth key
-GATE_OAUTH_CLIENT_KEY   - Your client secret key
-GATE_OAUTH_API_KEY      - Your API key
-GATE_HOSTED_DOMAIN      - The hosted domain for gmail
-GATE_SERVER_URL         - Gate server FQDN
-GATE_CONFIG_SECRET      - Ruby required config secret key in production environment
-GATE_EMAIL_DOMAIN       - Your company's domain for email address
+GATE_OAUTH_CLIENT_ID      - Your OAuth client key
+GATE_OAUTH_CLIENT_SECRET  - Your OAUTH client secret
+GATE_HOSTED_DOMAIN        - The hosted domain for gmail
+GATE_SERVER_URL           - Gate server FQDN
+GATE_CONFIG_SECRET        - Ruby required config secret key in production environment
+GATE_EMAIL_DOMAIN         - Your company's domain for email address
 ```
 
 * Run bundle exec rake db:create db:migrate db:seed

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.omniauth :google_oauth2, ENV['GATE_OAUTH_API_KEY'], ENV['GATE_OAUTH_CLIENT_KEY'] , { hd: ENV['GATE_HOSTED_DOMAIN'], site: ENV['GATE_SERVER_URL'] }
+  config.omniauth :google_oauth2, ENV['GATE_OAUTH_CLIENT_ID'], ENV['GATE_OAUTH_CLIENT_SECRET'] , { hd: ENV['GATE_HOSTED_DOMAIN'], site: ENV['GATE_SERVER_URL'] }
 
   config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
   config.secret_key = ENV['GATE_CONFIG_SECRET']


### PR DESCRIPTION
The OAuth environment variables are named incorrectly at the moment. `GATE_OAUTH_API_KEY` is actually being used as the `client_id`, and  `GATE_OAUTH_CLIENT_KEY` as the `client_secret` (see https://github.com/gate-sso/gate/blob/master/config/initializers/devise.rb#L15). Additionally,`GATE_OAUTH_SECRET` isn't actually referenced anywhere.

This causes problems since it's impossible to know what value to assign to what variable without reading the code (see https://github.com/gate-sso/gate/issues/14). This PR updates the names to reflect what values they should contain, and removes the unused one.