### PR TITLE
Use alpine and optimize image build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM jruby:9.1.7.0
+FROM jruby:9.1-alpine
 LABEL maintainer <vjdhama26@gmail.com>
 
-RUN apt-get update -qq && apt-get install -y build-essential libmysqlclient-dev nodejs
 RUN mkdir /app
 
 WORKDIR /app
@@ -9,7 +8,10 @@ WORKDIR /app
 COPY Gemfile /app
 COPY Gemfile.lock /app
 
-RUN bundle install
+RUN apk --update add build-base nodejs mariadb-dev mariadb-client-libs tzdata && \
+    bundle install && \
+    apk del build-base mariadb-dev && \
+    rm -rf /tmp/* /var/tmp/* /var/cache/apk/*
 
 ADD . /app
 


### PR DESCRIPTION
This results in a far smaller docker image:

```
REPOSITORY                                              TAG                                        IMAGE ID            CREATED             SIZE
ptlange/gate                                            alpine                                     0dd5e93e68b9        9 minutes ago       247MB
ptlange/gate                                            latest                                     1dd55e27a242        28 minutes ago      676MB
```