### PR TITLE
Show API access_key only once

### DIFF
--- a/app/controllers/api_resources_controller.rb
+++ b/app/controllers/api_resources_controller.rb
@@ -1,6 +1,6 @@
 class ApiResourcesController < ApplicationController
   before_action :set_api_resource, only: [:show, :edit, :update, :destroy]
-  before_filter :authenticate_user!, :except => [:authenticate] 
+  before_filter :authenticate_user!, :except => [:authenticate]
 
   # GET /api_resources
   # GET /api_resources.json
@@ -26,7 +26,7 @@ class ApiResourcesController < ApplicationController
   # GET /api_resources/new
   def new
     @api_resource = ApiResource.new
-    @api_resource.access_key = ROTP::Base32.random_base32 
+    @api_resource.access_key = ROTP::Base32.random_base32
   end
 
   # GET /api_resources/1/edit
@@ -36,7 +36,6 @@ class ApiResourcesController < ApplicationController
   # POST /api_resources
   # POST /api_resources.json
   def create
-
     @api_resource = ApiResource.new(api_resource_params)
     @api_resource.user = current_user
     group = Group.create name: "#{@api_resource.name}_api_group"

--- a/app/controllers/api_resources_controller.rb
+++ b/app/controllers/api_resources_controller.rb
@@ -26,7 +26,6 @@ class ApiResourcesController < ApplicationController
   # GET /api_resources/new
   def new
     @api_resource = ApiResource.new
-    @api_resource.access_key = ROTP::Base32.random_base32
   end
 
   # GET /api_resources/1/edit
@@ -37,6 +36,7 @@ class ApiResourcesController < ApplicationController
   # POST /api_resources.json
   def create
     @api_resource = ApiResource.new(api_resource_params)
+    @api_resource.access_key = ROTP::Base32.random_base32
     @api_resource.user = current_user
     group = Group.create name: "#{@api_resource.name}_api_group"
     @api_resource.group = group
@@ -44,7 +44,7 @@ class ApiResourcesController < ApplicationController
     group.save!
     respond_to do |format|
       if @api_resource.save
-        format.html { redirect_to api_resources_path, notice: 'Api resource was successfully created.' }
+        format.html { redirect_to api_resource_path(@api_resource.id), notice: 'Api resource was successfully created.', flash: {access_key: @api_resource.access_key} }
         format.json { render :show, status: :created, location: @api_resource }
       else
         format.html { render :new }

--- a/app/controllers/api_resources_controller.rb
+++ b/app/controllers/api_resources_controller.rb
@@ -1,5 +1,5 @@
 class ApiResourcesController < ApplicationController
-  before_action :set_api_resource, only: [:show, :edit, :update, :destroy]
+  before_action :set_api_resource, only: [:show, :edit, :update, :destroy, :regenerate_access_key]
   before_filter :authenticate_user!, :except => [:authenticate]
 
   # GET /api_resources
@@ -90,6 +90,20 @@ class ApiResourcesController < ApplicationController
     @api_resources = @api_resources.order("name ASC").limit(20)
     data = @api_resources.map{ |group| {id: group.id, name: group.name} }
     render json: data
+  end
+
+  # GET /api_resources/:id/regenerate_access_key
+  def regenerate_access_key
+    @api_resource.access_key = ROTP::Base32.random_base32
+    respond_to do |format|
+      if @api_resource.save
+        format.html { redirect_to api_resource_path(@api_resource.id), notice: 'Access key regenerated.', flash: {access_key: @api_resource.access_key} }
+        format.json { render :show, status: :ok, location: @api_resource }
+      else
+        format.html { redirect_to api_resource_path(@api_resource.id), notice: 'Access key failed to regenerate.' }
+        format.json { render json: @api_resource.errors, status: :unprocessable_entity }
+      end
+    end
   end
 
   private

--- a/app/models/api_resource.rb
+++ b/app/models/api_resource.rb
@@ -1,12 +1,22 @@
 class ApiResource < ActiveRecord::Base
+  attr_accessor :access_key
+
   validates :name, format: { with: /\A[a-zA-Z0-9_-]+\Z/ }, uniqueness: true, presence: true
-  validates :access_key, presence: true
+  validates :access_key, presence: true, on: :create
   belongs_to :user
   belongs_to :group
 
+  before_save :hash_access_key!
+
   def self.authenticate access_key, access_token
-    api_resource = ApiResource.find_by(access_key: access_key)
+    api_resource = ApiResource.find_by(hashed_access_key: Digest::SHA512.hexdigest(access_key))
     user = AccessToken.find_by(token: access_token).user
     api_resource.group.member? user
+  end
+
+  private
+
+  def hash_access_key!
+    self.hashed_access_key = Digest::SHA512.hexdigest self.access_key unless self.access_key.blank?
   end
 end

--- a/app/views/api_resources/_form.html.slim
+++ b/app/views/api_resources/_form.html.slim
@@ -17,12 +17,5 @@
         | Description
       = f.text_field :description, required: true, class: "form-control", placeholder: "Description"
       .invalid-feedback
-    - if @api_resource.access_key
-      .mb-3
-        label for="access_key"
-          | Access Key
-        .alert.alert-warning role="alert"
-          | Important! please make note of this access key, you will only see it once.
-        = f.text_field :access_key, class: 'form-control', readonly: ""
     .mb-4
       = f.submit "Save", class: "btn btn-primary pull-right"

--- a/app/views/api_resources/_form.html.slim
+++ b/app/views/api_resources/_form.html.slim
@@ -17,9 +17,12 @@
         | Description
       = f.text_field :description, required: true, class: "form-control", placeholder: "Description"
       .invalid-feedback
-    .mb-3
-      label for="access_key" 
-        | Access Key
-      = f.text_field :access_key, required: true, class: 'form-control', readonly: ""
+    - if @api_resource.access_key
+      .mb-3
+        label for="access_key"
+          | Access Key
+        .alert.alert-warning role="alert"
+          | Important! please make note of this access key, you will only see it once.
+        = f.text_field :access_key, class: 'form-control', readonly: ""
     .mb-4
       = f.submit "Save", class: "btn btn-primary pull-right"

--- a/app/views/api_resources/index.html.slim
+++ b/app/views/api_resources/index.html.slim
@@ -22,7 +22,7 @@
         tr
           td = api_resource.name
           td = api_resource.description
-          td = "********"
+          td = link_to 'Regenerate', regenerate_access_key_api_resource_path(api_resource), data: { confirm: 'Are you sure?' }
           td = link_to api_resource.user.name, api_resource.user if api_resource.user.present?
           td = link_to api_resource.group.name, api_resource.group if api_resource.group.present?
           td = link_to 'Destroy', api_resource, data: { confirm: 'Are you sure?' }, method: :delete

--- a/app/views/api_resources/index.html.slim
+++ b/app/views/api_resources/index.html.slim
@@ -22,7 +22,7 @@
         tr
           td = api_resource.name
           td = api_resource.description
-          td = api_resource.access_key
+          td = "********"
           td = link_to api_resource.user.name, api_resource.user if api_resource.user.present?
           td = link_to api_resource.group.name, api_resource.group if api_resource.group.present?
           td = link_to 'Destroy', api_resource, data: { confirm: 'Are you sure?' }, method: :delete

--- a/app/views/api_resources/show.html.slim
+++ b/app/views/api_resources/show.html.slim
@@ -1,15 +1,30 @@
-p#notice = notice
+.container-fluid.col-md-4.col-md-offset-4
+  - if notice.present?
+    .alert.alert-primary role="alert"
+      #notice
+        = notice
+  br
+  h5 Show API
 
-p
-  strong Name:
-  = @api_resource.name
-p
-  strong Description:
-  = @api_resource.description
-p
-  strong Access key:
-  = "********"
-
-=> link_to 'Edit', edit_api_resource_path(@api_resource)
-'|
-=< link_to 'Back', api_resources_path
+  hr
+    .mb-3
+      label for="name"
+        | API Name
+      p.form-control-static
+        = @api_resource.name
+    .mb-3
+      label for="description"
+        | Description
+      p.form-control-static
+        = @api_resource.description
+    - if flash[:access_key]
+      .mb-3
+        label for="access_key"
+          | Access Key
+        .alert.alert-warning role="alert"
+          | Important! please make note of this access key, you will see it only this once.
+        = text_field_tag :access_key, flash[:access_key], class: 'form-control', readonly: ""
+    .mb-4
+      => link_to 'Edit', edit_api_resource_path(@api_resource)
+      '|
+      =< link_to 'Back', api_resources_path

--- a/app/views/api_resources/show.html.slim
+++ b/app/views/api_resources/show.html.slim
@@ -8,7 +8,7 @@ p
   = @api_resource.description
 p
   strong Access key:
-  = @api_resource.access_key
+  = "********"
 
 => link_to 'Edit', edit_api_resource_path(@api_resource)
 '|

--- a/app/views/api_resources/show.html.slim
+++ b/app/views/api_resources/show.html.slim
@@ -27,4 +27,6 @@
     .mb-4
       => link_to 'Edit', edit_api_resource_path(@api_resource)
       '|
+      => link_to 'Regenerate Access Key', regenerate_access_key_api_resource_path(@api_resource), :data => {:confirm => 'Are you sure?'}
+      '|
       =< link_to 'Back', api_resources_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,9 @@ Rails.application.routes.draw do
     collection do
       get 'search', format: :json
     end
+    member do
+      get 'regenerate_access_key'
+    end
   end
 
   get "api_resource/authenticate/:access_key/:access_token" => "api_resources#authenticate", as: "api_resource_authenticate"

--- a/db/migrate/20180311082600_rename_access_key_in_api_resources.rb
+++ b/db/migrate/20180311082600_rename_access_key_in_api_resources.rb
@@ -1,0 +1,5 @@
+class RenameAccessKeyInApiResources < ActiveRecord::Migration
+  def change
+    rename_column :api_resources, :access_key, :hashed_access_key
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180306231200) do
+ActiveRecord::Schema.define(version: 20180311082600) do
 
   create_table "access_tokens", force: :cascade do |t|
     t.string   "token",      limit: 255
@@ -23,13 +23,13 @@ ActiveRecord::Schema.define(version: 20180306231200) do
   add_index "access_tokens", ["user_id"], name: "fk_rails_96fc070778", using: :btree
 
   create_table "api_resources", force: :cascade do |t|
-    t.string   "name",        limit: 255
-    t.string   "description", limit: 255
-    t.string   "access_key",  limit: 255
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-    t.integer  "user_id",     limit: 4
-    t.integer  "group_id",    limit: 4
+    t.string   "name",              limit: 255
+    t.string   "description",       limit: 255
+    t.string   "hashed_access_key", limit: 255
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.integer  "user_id",           limit: 4
+    t.integer  "group_id",          limit: 4
   end
 
   add_index "api_resources", ["group_id"], name: "index_api_resources_on_group_id", using: :btree

--- a/spec/controllers/api_resources_controller_spec.rb
+++ b/spec/controllers/api_resources_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe ApiResourcesController, type: :controller do
 
       it "redirects to the created api_resource" do
         post :create, {:api_resource => valid_attributes}, valid_session
-        expect(response).to redirect_to(api_resources_url)
+        expect(response).to redirect_to(api_resource_path(assigns[:api_resource]))
       end
     end
 

--- a/spec/controllers/api_resources_controller_spec.rb
+++ b/spec/controllers/api_resources_controller_spec.rb
@@ -137,6 +137,22 @@ RSpec.describe ApiResourcesController, type: :controller do
     end
   end
 
+  describe "PUT #update" do
+    it "regenerates access_key of the requested api_resource" do
+      api_resource = ApiResource.create! valid_attributes
+      old_hashed_access_key = api_resource.hashed_access_key
+      get :regenerate_access_key, {:id => api_resource.to_param}, valid_session
+      api_resource.reload
+      expect(api_resource.hashed_access_key).to_not eq old_hashed_access_key
+    end
+
+    it "redirects to the api_resource" do
+      api_resource = ApiResource.create! valid_attributes
+      get :regenerate_access_key, {:id => api_resource.to_param}
+      expect(response).to redirect_to(api_resource_path(api_resource.id))
+    end
+  end
+
   describe "Authenticate" do
     it "should not authenticate if a user is NOT a member of API group" do
       user = create :user

--- a/spec/controllers/api_resources_controller_spec.rb
+++ b/spec/controllers/api_resources_controller_spec.rb
@@ -9,14 +9,18 @@ RSpec.describe ApiResourcesController, type: :controller do
   let(:user) { FactoryBot.create(:user, name: "foobar", admin: true, user_login_id: "foobar", email: "foobar@foobar.com")  }
   let(:group) { FactoryBot.create(:group, name: "foobar_group") }
   let(:valid_attributes) do
-    {name: "sample_api", description: "sample_api_description",access_key: "xcz" , user_id: user, group_id: group}
+    {
+      name: "sample_api",
+      description: "sample_api_description",
+      access_key: "xcz",
+      user_id: user,
+      group_id: group
+    }
   end
-
 
   let(:invalid_attributes) {
     { name: "non sample api", description: 100}
   }
-
 
   # This should return the minimal set of values that should be in the session
   # in order to pass any filters (e.g. authentication) defined in
@@ -134,7 +138,7 @@ RSpec.describe ApiResourcesController, type: :controller do
   end
 
   describe "Authenticate" do
-    it "should not authenticate if a user is member of API group" do
+    it "should not authenticate if a user is NOT a member of API group" do
       user = create :user
       access_token = create :access_token
       user.access_token = access_token
@@ -151,8 +155,7 @@ RSpec.describe ApiResourcesController, type: :controller do
       expect(body["result"]).to eq 1
     end
 
-    it "should not authenticate if a user is NOT a member of API group" do
-
+    it "should authenticate if a user is member of API group" do
       user = create :user
       access_token = create :access_token
       user.access_token = access_token

--- a/spec/controllers/api_resources_controller_spec.rb
+++ b/spec/controllers/api_resources_controller_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe ApiResourcesController, type: :controller do
       api_resource = ApiResource.create! valid_attributes
       api_resource.group = group
       api_resource.save!
-      get :authenticate, { access_key: api_resource.access_key, access_token: user.access_token.token }, valid_session
+      get :authenticate, { access_key: valid_attributes[:access_key], access_token: user.access_token.token }, valid_session
       expect(response).not_to be_success
       body = JSON.parse(response.body)
       expect(body["result"]).to eq 1
@@ -164,7 +164,7 @@ RSpec.describe ApiResourcesController, type: :controller do
       api_resource.group = group
       group.users << user
       api_resource.save!
-      get :authenticate, { access_key: api_resource.access_key, access_token: user.access_token.token }, valid_session
+      get :authenticate, { access_key: valid_attributes[:access_key], access_token: user.access_token.token }, valid_session
       expect(response).to be_success
       body = JSON.parse(response.body)
       expect(body["result"]).to eq 0

--- a/spec/models/api_resource_spec.rb
+++ b/spec/models/api_resource_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe ApiResource, type: :model do
+  let(:user) {
+    FactoryBot.create(:user,
+      name: "foobar",
+      admin: true,
+      user_login_id: "foobar",
+      email: "foobar@foobar.com"
+    )
+  }
+  let(:group) { FactoryBot.create(:group, name: "foobar_group") }
+  let(:valid_attributes) do
+    {
+      name: "sample_api",
+      description: "sample_api_description",
+      access_key: "xcz",
+      user_id: user.id,
+      group_id: group.id
+    }
+  end
+
+  describe "self.authenticate" do
+    it "should return true if it finds matching access_key and the user is member of the group" do
+      api_resource = ApiResource.create(valid_attributes)
+      group.users << user
+      access_token = AccessToken.new
+      access_token.token = ROTP::Base32.random_base32
+      access_token.user = user
+      access_token.save!
+      expect(ApiResource.authenticate(valid_attributes[:access_key], access_token.token)).to eq true
+    end
+  end
+
+  describe "hash_access_key! before_save" do
+    it "should hash access_key and put it into hashed_access_key" do
+      api_resource = ApiResource.create(valid_attributes)
+      expect(api_resource.hashed_access_key).to eq(
+        Digest::SHA512.hexdigest(valid_attributes[:access_key]))
+    end
+
+    it "shouldn't change hashed_access_key if access_key isn't supplied" do
+      api_resource = ApiResource.create(valid_attributes)
+      api_resource.update(description: "Change Description")
+      expect(api_resource.hashed_access_key).to eq(
+        Digest::SHA512.hexdigest(valid_attributes[:access_key]))
+    end
+  end
+end

--- a/spec/views/api_resources/edit.html.slim_spec.rb
+++ b/spec/views/api_resources/edit.html.slim_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe "api_resources/edit", type: :view do
       assert_select "input#api_resource_name[name=?]", "api_resource[name]"
 
       assert_select "input#api_resource_description[name=?]", "api_resource[description]"
-
-      assert_select "input#api_resource_access_key[name=?]", "api_resource[access_key]"
     end
   end
 end

--- a/spec/views/api_resources/index.html.slim_spec.rb
+++ b/spec/views/api_resources/index.html.slim_spec.rb
@@ -20,6 +20,6 @@ RSpec.describe "api_resources/index", type: :view do
     render
     assert_select "tr>td", :text => "Name".to_s, :count => 1
     assert_select "tr>td", :text => "Description".to_s, :count => 2
-    assert_select "tr>td", :text => "Access Key".to_s, :count => 2
+    assert_select "tr>td", :text => "********".to_s, :count => 2
   end
 end

--- a/spec/views/api_resources/index.html.slim_spec.rb
+++ b/spec/views/api_resources/index.html.slim_spec.rb
@@ -20,6 +20,6 @@ RSpec.describe "api_resources/index", type: :view do
     render
     assert_select "tr>td", :text => "Name".to_s, :count => 1
     assert_select "tr>td", :text => "Description".to_s, :count => 2
-    assert_select "tr>td", :text => "********".to_s, :count => 2
+    assert_select "tr>td", :text => "Regenerate".to_s, :count => 2
   end
 end

--- a/spec/views/api_resources/new.html.slim_spec.rb
+++ b/spec/views/api_resources/new.html.slim_spec.rb
@@ -17,8 +17,6 @@ RSpec.describe "api_resources/new", type: :view do
       assert_select "input#api_resource_name[name=?]", "api_resource[name]"
 
       assert_select "input#api_resource_description[name=?]", "api_resource[description]"
-
-      assert_select "input#api_resource_access_key[name=?]", "api_resource[access_key]"
     end
   end
 end

--- a/spec/views/api_resources/show.html.slim_spec.rb
+++ b/spec/views/api_resources/show.html.slim_spec.rb
@@ -13,6 +13,6 @@ RSpec.describe "api_resources/show", type: :view do
     render
     expect(rendered).to match(/Name/)
     expect(rendered).to match(/Description/)
-    expect(rendered).to match(/\*\*\*\*\*\*\*\*/)
+    expect(rendered).to match(/Access Key/)
   end
 end

--- a/spec/views/api_resources/show.html.slim_spec.rb
+++ b/spec/views/api_resources/show.html.slim_spec.rb
@@ -13,6 +13,6 @@ RSpec.describe "api_resources/show", type: :view do
     render
     expect(rendered).to match(/Name/)
     expect(rendered).to match(/Description/)
-    expect(rendered).to match(/Access Key/)
+    expect(rendered).to match(/\*\*\*\*\*\*\*\*/)
   end
 end


### PR DESCRIPTION
For API Resource
- Only show access_key once and store it as hash
- Add 'regenerate' function for access_key