### PR TITLE
Setup Newrelic & STDOUT logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,4 +49,5 @@ gem 'paper_trail'
 gem 'saml_idp', :git => "https://github.com/gate-sso/saml_idp.git"
 
 gem 'figaro'
+gem 'newrelic_rpm'
 gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     mysql2 (0.4.10)
+    newrelic_rpm (4.8.0.341)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     nokogiri (1.8.2-java)
@@ -290,6 +291,7 @@ DEPENDENCIES
   jdbc-mysql
   jquery-rails
   mysql2
+  newrelic_rpm
   omniauth
   omniauth-google-oauth2
   paper_trail

--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ You might have to open rails console and give one user admin privileges by setti
 
 The puma logs are in `shared/log/puma.stdout.log`  and `shared/log/puma.stderr.log` and the app logs are in `log/<env>.log`, some errors may be being written directly to stdout/stderr and may not be available in the application's log file
 
+#### Newrelic Support
+
+If you want to enable Newrelic monitoring on your Gate deployment, you just have to create these additional keys on your environment variables:
+
+```
+NEWRELIC_LICENSE_KEY                - Your Newrelic license key
+NEWRELIC_APP_NAME                   - Your application name (identifer) on Newrelic
+NEWRELIC_AGENT_ENABLED              - Set it true if you want Newrelic agent to runs
+```
+
 #### Scheduler
 
 Gate has several tasks that can be scheduled for maintenance purpose. Please see `config/scheduler.rb` to see the list of tasks. 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,6 +74,14 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
+  # Enable option to log into STDOUT
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    STDOUT.sync = true
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
+
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -18,7 +18,7 @@ common: &default_settings
 # If your application has other named environments, configure them here.
 development:
   <<: *default_settings
-  app_name: <%= Figaro.env.NEWRELIC_APP_NAME %> (Development)
+  app_name: <%= Figaro.env.NEWRELIC_APP_NAME + "(Development)" %>
 
 test:
   <<: *default_settings

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,0 +1,29 @@
+common: &default_settings
+  # Required license key associated with your New Relic account.
+  license_key: <%= Figaro.env.NEWRELIC_LICENSE_KEY %>
+
+  # Your application name. Renaming here affects where data displays in New
+  # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
+  app_name: <%= Figaro.env.NEWRELIC_APP_NAME %>
+
+  # To disable the agent regardless of other settings, uncomment the following:
+  agent_enabled: <%= Figaro.env.NEWRELIC_AGENT_ENABLED || false %>
+
+  # Logging level for log/newrelic_agent.log
+  log_level: info
+
+
+# Environment-specific settings are in this section.
+# RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
+# If your application has other named environments, configure them here.
+development:
+  <<: *default_settings
+  app_name: <%= Figaro.env.NEWRELIC_APP_NAME %> (Development)
+
+test:
+  <<: *default_settings
+  # It doesn't make sense to report to New Relic from automated test runs.
+  monitor_mode: false
+
+production:
+  <<: *default_settings


### PR DESCRIPTION
To increase visibility of a running gate deployment, I create support for Newrelic in this PR. I set it so that it's turned off by default and also add guide on how to enable it on README.

I also backport rails 5 way of toggling log to STDOUT in production environment