### PR TITLE
Background image covers viewport

### DIFF
--- a/app/assets/stylesheets/home.scss.erb
+++ b/app/assets/stylesheets/home.scss.erb
@@ -33,9 +33,10 @@ body {
   line-height: 30px;
   text-align: center;
   background-image: image-url('bg.jpeg');
-  background-size: 100%;
+  background-size: cover;
   background-repeat: no-repeat;
   background-color: #444444;
+  background-position: 50%;
 }
 
 .form-signin {


### PR DESCRIPTION
Background image on home screen was not covering full viewport &
didn't look good on smaller screens. This fix covers the viewport &
makes the image centered relative to the viewport.

Fixes #108 