### PR TITLE
Add before_install section in .travis.yml to install bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,10 @@ env:
   - COMMIT=${TRAVIS_COMMIT::8}
   - DOCKER_COMPOSE_VERSION=1.11.2
 
+before_install:
+  - gem update --system
+  - gem install bundler
+
 stages:
   - build, test and releases
   - name: build and publish docker


### PR DESCRIPTION
There was a problem on travis CI pipeline regarding bundler gem not found.
According to the documentation [here](https://docs.travis-ci.com/user/languages/ruby/#bundler-20), we need to install bundler on before_install phase.

@giosakti 