### PR TITLE
Auto revoke admin when deactivated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Use dotenv instead of figaro. This is a breaking change and warrant a major version release.
 - All spiders are banned by default now in `robots.txt`
+- When admin account become inactive, the admin status will automatically revoked.
 
 ## [0.1.0] - 2019-05-20
 ### Changed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,8 @@ class User < ApplicationRecord
 
   validate :remove_default_admin, on: :update
 
+  before_save :revoke_admin_when_inactive, on: :update
+
   HOME_DIR = '/home'.freeze
   USER_SHELL = '/bin/bash'.freeze
 
@@ -407,5 +409,9 @@ class User < ApplicationRecord
     domain_list = ENV['GATE_HOSTED_DOMAINS'].split(',')
     domain = email.split('@').last
     errors.add(:email, "Invalid Domain for Email Address") unless domain_list.include?(domain)
+  end
+
+  def revoke_admin_when_inactive
+    self.admin = false unless active
   end
 end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -17,8 +17,9 @@ describe ProfileController, type: :controller do
         sign_in admin
 
         post :update, params: { id: new_user.id, user: { admin: false, active: false } }
+        new_user.reload
 
-        expect(User.find(new_user.id)).to have_attributes(active: false, admin: false)
+        expect(new_user).to have_attributes(active: false, admin: false)
       end
 
       it 'should revoke admin when deactivate user' do
@@ -26,8 +27,9 @@ describe ProfileController, type: :controller do
         sign_in admin
 
         post :update, params: { id: new_user.id, user: { active: false } }
+        new_user.reload
 
-        expect(User.find(new_user.id)).to have_attributes(active: false, admin: false)
+        expect(new_user).to have_attributes(active: false, admin: false)
       end
 
       it 'should redirect to user_path after update' do
@@ -45,8 +47,9 @@ describe ProfileController, type: :controller do
         sign_in user
 
         post :update, params: { id: new_user.id, user: { admin: false, active: false } }
+        new_user.reload
 
-        expect(User.find(new_user.id)).to have_attributes(active: true, admin: true)
+        expect(new_user).to have_attributes(active: true, admin: true)
       end
     end
   end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -1,11 +1,23 @@
 describe ProfileController, type: :controller do
+  let!(:admin) { create(:admin_user) }
   let(:user) { create(:user) }
+
   describe '#update' do
     context 'unauthenticated' do
       it 'should return status 302' do
         post :update, params: { id: user.id }
 
         expect(response).to have_http_status(302)
+      end
+    end
+
+    context 'authenticated as admin' do
+      it 'should redirect to user_path after update' do
+        sign_in admin
+
+        post :update, params: { id: user.id, user: { admin: false, active: false } }
+
+        expect(response).to redirect_to(user_path)
       end
     end
   end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -1,6 +1,6 @@
 describe ProfileController, type: :controller do
   let!(:admin) { create(:admin_user) }
-  let(:user) { create(:user) }
+  let(:user) { create(:user, admin: false) }
 
   describe '#update' do
     context 'unauthenticated' do
@@ -27,6 +27,17 @@ describe ProfileController, type: :controller do
         post :update, params: { id: user.id, user: { admin: false, active: false } }
 
         expect(response).to redirect_to(user_path)
+      end
+    end
+
+    context 'authenticated as non admin' do
+      it 'should not update user' do
+        new_user = create(:user, active: true, admin: true)
+        sign_in user
+
+        post :update, params: { id: new_user.id, user: { admin: false, active: false } }
+
+        expect(User.find(new_user.id)).to have_attributes(active: true, admin: true)
       end
     end
   end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -12,6 +12,15 @@ describe ProfileController, type: :controller do
     end
 
     context 'authenticated as admin' do
+      it 'should update user' do
+        new_user = create(:user, active: true, admin: true)
+        sign_in admin
+
+        post :update, params: { id: new_user.id, user: { admin: false, active: false } }
+
+        expect(User.find(new_user.id)).to have_attributes(active: false, admin: false)
+      end
+
       it 'should redirect to user_path after update' do
         sign_in admin
 

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -1,0 +1,12 @@
+describe ProfileController, type: :controller do
+  let(:user) { create(:user) }
+  describe '#update' do
+    context 'unauthenticated' do
+      it 'should return status 302' do
+        post :update, params: { id: user.id }
+
+        expect(response).to have_http_status(302)
+      end
+    end
+  end
+end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -21,6 +21,15 @@ describe ProfileController, type: :controller do
         expect(User.find(new_user.id)).to have_attributes(active: false, admin: false)
       end
 
+      it 'should revoke admin when deactivate user' do
+        new_user = create(:user, active: true, admin: true)
+        sign_in admin
+
+        post :update, params: { id: new_user.id, user: { active: false } }
+
+        expect(User.find(new_user.id)).to have_attributes(active: false, admin: false)
+      end
+
       it 'should redirect to user_path after update' do
         sign_in admin
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -243,6 +243,20 @@ RSpec.describe User, type: :model do
       expect(user.valid?).to eq(false)
     end
   end
+
+  describe '#update' do
+    context 'deactivate admin user' do
+      it 'should revoke admin status' do
+        create(:admin_user)
+        admin = create(:admin_user)
+
+        admin.update(active: false)
+        admin.reload
+
+        expect(admin.admin?).to be false
+      end
+    end
+  end
 end
 
 UID_CONSTANT = 5000


### PR DESCRIPTION
When an admin account deactivated, then admin status will be revoked.
This behaviour is handled by the user model.

@giosakti