### PR TITLE
Fix travis ci docker deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,6 @@ jobs:
         on:
           tags: true
           repo: gate-sso/gate
-          branch: master
     - stage: build and publish docker
       install: skip
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
 stages:
   - build, test and releases
   - name: build and publish docker
-    if: branch = master and type != pull_request
+    if: (branch = master OR tag IS present) and type != pull_request
 
 jobs:
   include:


### PR DESCRIPTION
According to [this](https://docs.travis-ci.com/user/deployment#conditional-releases-with-on), when we set `tags: true` then the `branch: master` is ignored.

Docker push will do when on master branch(latest release) or tagged commit(tagged release).