### PR TITLE
User without vpn download vpn for mac

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -87,7 +87,7 @@ class ProfileController < ApplicationController
     mobileconfig = Mobileconfig.new
     vpns = Vpn.user_vpns current_user
 
-    render plain: "you don't have access to any vpns" && return unless vpns.present?
+    return render plain: "you don't have access to any vpns" unless vpns.present?
 
     mobileconfig_data = mobileconfig.generate(vpns, current_user)
 

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -53,4 +53,16 @@ describe ProfileController, type: :controller do
       end
     end
   end
+
+  describe '#download_vpn_for_ios_and_mac' do
+    context "user doesn't have vpn" do
+      it 'should return status 200' do
+        sign_in user
+
+        get :download_vpn_for_ios_and_mac
+
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
 end


### PR DESCRIPTION
User without vpn when download vpn for mac should not throw error.