### PR TITLE
Optimize passwd api

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,8 +116,7 @@ class User < ApplicationRecord
         ) AS gid
       )).
       where(id: user_ids)
-    user_list = users.map{ |user| user.get_passwd_uid_response(user) }
-    user_list
+    users.map(&:get_passwd_uid_response)
   end
 
   def purge!
@@ -313,9 +312,8 @@ class User < ApplicationRecord
     user_response
   end
 
-  def get_passwd_uid_response user
-    return [] if user.blank?
-    user.user_passwd_response
+  def get_passwd_uid_response
+    user_passwd_response
   end
 
   def self.find_active_user_by_email(email)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,7 +116,7 @@ class User < ApplicationRecord
         ) AS gid
       )).
       where(id: user_ids)
-    user_list = users.map{ |user| get_passwd_uid_response(user) }
+    user_list = users.map{ |user| user.get_passwd_uid_response(user) }
     user_list
   end
 
@@ -313,7 +313,7 @@ class User < ApplicationRecord
     user_response
   end
 
-  def self.get_passwd_uid_response user
+  def get_passwd_uid_response user
     return [] if user.blank?
     user.user_passwd_response
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -116,7 +116,7 @@ class User < ApplicationRecord
         ) AS gid
       )).
       where(id: user_ids)
-    users.map(&:get_passwd_uid_response)
+    users.map(&:user_passwd_response)
   end
 
   def purge!
@@ -310,10 +310,6 @@ class User < ApplicationRecord
     user_response = []
     user_response << response
     user_response
-  end
-
-  def get_passwd_uid_response
-    user_passwd_response
   end
 
   def self.find_active_user_by_email(email)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -113,7 +113,16 @@ class User < ApplicationRecord
           WHERE group_associations.user_id = users.id
           AND groups.name = users.user_login_id
           LIMIT 1
-        ) AS gid
+        ) AS gid,
+        (
+          SELECT COUNT(gid)
+          FROM groups
+          INNER JOIN group_associations
+            ON groups.id = group_associations.group_id
+          WHERE group_associations.user_id = users.id
+          AND groups.name = users.user_login_id
+          LIMIT 1
+        ) AS gid_count
       )).
       where(id: user_ids)
     users.map(&:user_passwd_response)
@@ -370,19 +379,23 @@ class User < ApplicationRecord
   def user_passwd_response
     user_hash = {}
     user_hash[:pw_name] = user_login_id
-    user_hash[:pw_passwd]  = "x"
+    user_hash[:pw_passwd] = 'x'
     user_hash[:pw_uid] = uid.to_i
 
     # If gid is supplied (avoid N+1)
-    if self.respond_to?(:gid) && gid
+    if respond_to?(:gid) && gid
       user_hash[:pw_gid] = gid.to_i
-    else
-      user_hash[:pw_gid] = groups.where(name: user_login_id).first.gid if groups.where(name: user_login_id).count > 0
+    elsif respond_to?(:gid_count)
+      if gid_count.positive?
+        user_hash[:pw_gid] = groups.where(name: user_login_id).first.gid
+      end
+    elsif groups.where(name: user_login_id).count.positive?
+      user_hash[:pw_gid] = groups.where(name: user_login_id).first.gid
     end
 
-    user_hash[:pw_gecos]  = "#{name}"
+    user_hash[:pw_gecos] = name.to_s
     user_hash[:pw_dir] = "#{HOME_DIR}/#{user_login_id}"
-    user_hash[:pw_shell] = "/bin/bash"
+    user_hash[:pw_shell] = '/bin/bash'
     user_hash
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -688,6 +688,12 @@ RSpec.describe User, type: :model do
       pw_name_sysadmins = sysadmins.map { |sysadmin| sysadmin[:pw_name] }
       expect(pw_name_sysadmins).to include user.user_login_id
     end
+
+    it 'should not included nil on pw_gid' do
+      sysadmins = User.get_sysadmins [user.id]
+      pw_gid_sysadmins = sysadmins.map { |sysadmin| sysadmin[:pw_gid] }
+      expect(pw_gid_sysadmins).not_to include nil
+    end
   end
 
   describe '.check_email_address' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -448,6 +448,16 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#get_passwd_uid_response' do
+    it 'should return response with pw_name equal user_login_id' do
+      user = create(:user)
+
+      response = user.get_passwd_uid_response
+
+      expect(response[:pw_name]).to eq(user.user_login_id)
+    end
+  end
+
   describe '.get_shadow_name_response' do
     it 'should return response with sp_namp equal user_login_id' do
       user = create(:user)
@@ -455,16 +465,6 @@ RSpec.describe User, type: :model do
       response = User.get_shadow_name_response user.name
 
       expect(response[:sp_namp]).to eq(user.user_login_id)
-    end
-  end
-
-  describe '.get_passwd_uid_response' do
-    it 'should return response with pw_name equal user_login_id' do
-      user = create(:user)
-
-      response = user.get_passwd_uid_response user
-
-      expect(response[:pw_name]).to eq(user.user_login_id)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -323,6 +323,22 @@ RSpec.describe User, type: :model do
       expect(user_expiration_date).to eq(expiration_date)
     end
   end
+
+  describe '.check_email_address' do
+    it 'should check valid email address' do
+      email_address = 'satrya@gmail.com'
+      expect(User.check_email_address(email_address)).to eq(true)
+
+      email_address = 'satraya @gmail.com'
+      expect(User.check_email_address(email_address)).to eq(false)
+
+      email_address = 'satraya@-gmail.com'
+      expect(User.check_email_address(email_address)).to eq(false)
+
+      email_address = 'sat*raya@gmail.com'
+      expect(User.check_email_address(email_address)).to eq(false)
+    end
+  end
 end
 
 UID_CONSTANT = 5000
@@ -330,21 +346,6 @@ RSpec.describe User, type: :model do
 
   before(:each) do
     create(:group)
-  end
-
-  it "should check valid email address" do
-    #email address always has 2 parts
-    email_address = "satrya@gmail.com"
-    expect(User.check_email_address(email_address)).to eq(true)
-
-    email_address = "satraya @gmail.com"
-    expect(User.check_email_address(email_address)).to eq(false)
-
-    email_address = "satraya@-gmail.com"
-    expect(User.check_email_address(email_address)).to eq(false)
-
-    email_address = "sat*raya@gmail.com"
-    expect(User.check_email_address(email_address)).to eq(false)
   end
 
   it "should check uid creation with offset" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -676,6 +676,14 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '.get_sysadmins' do
+    let(:user) { create(:user) }
+    it 'should return correct amount of sysadmins' do
+      sysadmins = User.get_sysadmins [user.id]
+      expect(sysadmins.size).to eq 1
+    end
+  end
+
   describe '.check_email_address' do
     it 'should check valid email address' do
       email_address = 'satrya@gmail.com'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -224,6 +224,14 @@ RSpec.describe User, type: :model do
       expect(user.public_key).to eq(attrs[:public_key])
     end
 
+    it 'should update the product name' do
+      name = 'test_product'
+
+      user.update_profile(product_name: name)
+
+      expect(user.product_name).to eq(name)
+    end
+
     it 'should update the name' do
       name = 'test_name'
 
@@ -294,19 +302,6 @@ RSpec.describe User, type: :model do
 
   before(:each) do
     create(:group)
-  end
-
-  context ".update_profile" do
-    before(:each) do
-      @user = create(:user)
-    end
-
-    it "should update the product name" do
-      name = "test_product"
-      @user.update_profile({ 'product_name' => name })
-      @user = User.find(@user.id)
-      expect(@user.product_name).to eq(name)
-    end
   end
 
   it "should set deactivation time when user is deactivated" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -682,6 +682,12 @@ RSpec.describe User, type: :model do
       sysadmins = User.get_sysadmins [user.id]
       expect(sysadmins.size).to eq 1
     end
+
+    it 'should include intended sysadmin' do
+      sysadmins = User.get_sysadmins [user.id]
+      pw_name_sysadmins = sysadmins.map { |sysadmin| sysadmin[:pw_name] }
+      expect(pw_name_sysadmins).to include user.user_login_id
+    end
   end
 
   describe '.check_email_address' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -224,6 +224,14 @@ RSpec.describe User, type: :model do
       expect(user.public_key).to eq(attrs[:public_key])
     end
 
+    it 'should update the name' do
+      name = 'test_name'
+
+      user.update_profile(name: name)
+
+      expect(user.name).to eq(name)
+    end
+
     it 'should update the public_key' do
       rsa_key = OpenSSL::PKey::RSA.new(2048)
       public_key = rsa_key.public_key.to_pem
@@ -291,13 +299,6 @@ RSpec.describe User, type: :model do
   context ".update_profile" do
     before(:each) do
       @user = create(:user)
-    end
-
-    it "should update the name" do
-      name = "test_name"
-      @user.update_profile({ 'name' => name })
-      @user = User.find(@user.id)
-      expect(@user.name).to eq(name)
     end
 
     it "should update the product name" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -690,10 +690,17 @@ RSpec.describe User, type: :model do
         expect(pw_name_sysadmins).to include user.user_login_id
       end
 
-      it 'should not included nil on pw_gid' do
+      it 'should return correct response without nil' do
         sysadmins = User.get_sysadmins [user.id]
-        pw_gid_sysadmins = sysadmins.map { |sysadmin| sysadmin[:pw_gid] }
-        expect(pw_gid_sysadmins).not_to include nil
+        expect(sysadmins.first).to satisfy do |sysadmin|
+          !sysadmin[:pw_name].nil? &&
+            !sysadmin[:pw_passwd].nil? &&
+            !sysadmin[:pw_uid].nil? &&
+            !sysadmin[:pw_gid].nil? &&
+            !sysadmin[:pw_gecos].nil? &&
+            !sysadmin[:pw_dir].nil? &&
+            !sysadmin[:pw_shell].nil?
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -332,6 +332,122 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#user_login_id' do
+    it 'should return _ for . in name' do
+      user = create(:user)
+      expect(user.user_login_id).to eq(user.email.split('@').first)
+      user = User.get_user(user.user_login_id)
+      expect(user).not_to be nil
+    end
+  end
+
+  describe '#permitted_hosts?' do
+    it 'should return false if user is not permitted' do
+      user = create(:user)
+
+      response = user.permitted_hosts? ['10.1.1.1.']
+
+      expect(response).to be false
+    end
+
+    it "should fails host address if it's not permitted" do
+      user = create(:user)
+      host = Host.new
+      host.user = user
+      host.host_pattern = 's*' # by default give host access to all staging instances
+      host.save!
+
+      expect(user.permitted_hosts?(['10.0.0.0'])).to be false
+    end
+
+    it "should pass host address if it's permitted" do
+      user = create(:user)
+      host = Host.new
+      host.user = user
+      host.host_pattern = '.*' # by default give host access to all staging instances
+      host.save!
+
+      expect(user.permitted_hosts?(['10.0.0.0'])).to be true
+    end
+  end
+
+  describe '#within_limits?' do
+    it 'login limits should pass' do
+      user = create(:user)
+      user.reset_login_limit
+      (RATE_LIMIT - 2).times do
+        user.within_limits?
+      end
+
+      expect(user.within_limits?).to be true
+    end
+
+    it 'login limits should fail' do
+      user = create(:user)
+      (RATE_LIMIT + 2).times do
+        user.within_limits?
+      end
+
+      expect(user.within_limits?).to be false
+    end
+  end
+
+  describe '#authenticate_ms_chap' do
+    it 'should authenticate ms chap' do
+      user = create(:user)
+      totp = '757364'
+      challenge_string = 'ee85e142eadfec52'
+      response_string = '0392a9e43edee3129f735b37fd9d0b0d3f66aa7a00f35440'
+
+      success_response = user.authenticate_ms_chap(totp, challenge_string, response_string)
+      unsuccessful_response = user.authenticate_ms_chap('78787', challenge_string, response_string)
+
+      expect(success_response).to eq('NT_KEY: 57247E8BAD1959F9544B2C5057F77AD8')
+      expect(unsuccessful_response).to eq('NT_STATUS_UNSUCCESSFUL: Failure (0xC0000001)')
+    end
+  end
+
+  describe '#authenticate_ms_chap_with_drift' do
+    it 'should authenticate ms chap with drift' do
+      user = create(:user)
+      challenge_string = 'ee85e142eadfec52'
+      response_string = '0392a9e43edee3129f735b37fd9d0b0d3f66aa7a00f35440'
+
+      totp = ['757364', '123456', '876543']
+      response = user.authenticate_ms_chap_with_drift(totp, challenge_string, response_string)
+      expect(response).to eq('NT_KEY: 57247E8BAD1959F9544B2C5057F77AD8')
+
+      totp = ['123456', '757364', '876543']
+      response = user.authenticate_ms_chap_with_drift(totp, challenge_string, response_string)
+      expect(response).to eq('NT_KEY: 57247E8BAD1959F9544B2C5057F77AD8')
+
+      totp = ['123456', '876543', '757364']
+      response = user.authenticate_ms_chap_with_drift(totp, challenge_string, response_string)
+      expect(response).to eq('NT_KEY: 57247E8BAD1959F9544B2C5057F77AD8')
+
+      totp = ['78787', '121212', '545454']
+      response = user.authenticate_ms_chap_with_drift(totp, challenge_string, response_string)
+      expect(response).to eq('NT_STATUS_UNSUCCESSFUL: Failure (0xC0000001)')
+    end
+  end
+
+  describe '#get_user_otp_at' do
+    it 'should return different otps for different times' do
+      user = create(:user)
+      user.auth_key = ROTP::Base32.random_base32
+      drift_interval = 30
+      t = Time.now
+
+      otp1 = user.get_user_otp_at(t)
+      otp2 = user.get_user_otp_at(t - drift_interval)
+      otp3 = user.get_user_otp_at(t + drift_interval)
+
+      expect(otp1).not_to equal(otp2)
+      expect(otp2).not_to equal(otp3)
+      expect(otp3).not_to equal(otp1)
+    end
+  end
+
   describe '.get_shadow_name_response' do
     it 'should return response with sp_namp equal user_login_id' do
       user = create(:user)
@@ -352,198 +468,106 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '.check_email_address' do
-    it 'should check valid email address' do
-      email_address = 'satrya@gmail.com'
-      expect(User.check_email_address(email_address)).to eq(true)
+  describe '.get_all_passwd_response' do
+    it 'should get all users for passwd' do
+      create_list(:user, 2)
 
-      email_address = 'satraya @gmail.com'
-      expect(User.check_email_address(email_address)).to eq(false)
+      response = User.get_all_passwd_response
 
-      email_address = 'satraya@-gmail.com'
-      expect(User.check_email_address(email_address)).to eq(false)
-
-      email_address = 'sat*raya@gmail.com'
-      expect(User.check_email_address(email_address)).to eq(false)
+      expect(response.count).to eq(2)
     end
   end
-end
 
-UID_CONSTANT = 5000
-RSpec.describe User, type: :model do
+  describe '.find_active_user_by_email' do
+    it 'should return user if email registered' do
+      email = Faker::Internet.email
+      create(:user, email: email)
 
-  before(:each) do
-    create(:group)
-  end
+      user = User.find_active_user_by_email(email)
 
-  it "should get all users for passwd" do
-    user = create(:user)
-    user = create(:user)
-
-    response = User.get_all_passwd_response
-    expect(response.count).to eq(2)
-  end
-
-  it "should return _ for . in name" do
-    user = create(:user)
-    expect(user.user_login_id).to eq(user.email.split("@").first)
-    user = User.get_user(user.user_login_id)
-    expect(user).not_to be nil
-  end
-
-  it "should return false if user is not permitted" do
-    user = create(:user)
-    response = user.permitted_hosts? ["10.1.1.1."]
-
-    expect(response).to eq (false)
-  end
-
-  it 'should return user if email registered' do
-    email = Faker::Internet.email
-    create(:user, email: email)
-    user = User.find_active_user_by_email(email)
-    expect(user.email).to eq(email)
-  end
-
-  it 'should return nil if email not registered' do
-    email = Faker::Internet.email
-    user = User.find_active_user_by_email(email)
-    expect(user.blank?).to eq(true)
-  end
-
-  it 'should return registered groups list' do
-    email = Faker::Internet.email
-    create(:user, email: email)
-    user = User.find_active_user_by_email(email)
-    expect(user.group_names_list.include?(user.user_login_id)).to eq(true)
-  end
-
-  it 'should check valid hosted domain' do
-    allow(ENV).to receive(:[]).with('GATE_HOSTED_DOMAINS').and_return('alfa.com,beta.com')
-    expect(User.valid_domain?('alfa.com')).to be true
-    expect(User.valid_domain?('beta.com')).to be true
-    expect(User.valid_domain?('gama.com')).to be false
-
-    allow(ENV).to receive(:[]).with('GATE_HOSTED_DOMAINS').and_return('')
-    expect(User.valid_domain?('alfa.com')).to be false
-  end
-
-  it "should fails host address if it's not permitted" do
-    user = create(:user)
-    host = Host.new
-    host.user = user
-    host.host_pattern = "s*" #by default give host access to all staging instances
-    host.save!
-    expect(user.permitted_hosts?(["10.0.0.0"])).to be false
-  end
-
-  it "should pass host address if it's permitted" do
-    user = create(:user)
-    host = Host.new
-    host.user = user
-    host.host_pattern = ".*" #by default give host access to all staging instances
-    host.save!
-    expect(user.permitted_hosts?(["10.0.0.0"])).to be true
-  end
-
-  it "login limits should pass" do
-    user = create(:user)
-    user.reset_login_limit
-    (RATE_LIMIT - 2).times do
-      user.within_limits?
+      expect(user.email).to eq(email)
     end
-    expect(user.within_limits?).to be true
-  end
 
-  it "login limits should fail" do
-    user = create(:user)
-    (RATE_LIMIT + 2).times do
-      user.within_limits?
+    it 'should return nil if email not registered' do
+      email = Faker::Internet.email
+
+      user = User.find_active_user_by_email(email)
+
+      expect(user).to be nil
     end
-    expect(user.within_limits?).to be false
+
+    it 'should return registered groups list' do
+      email = Faker::Internet.email
+      create(:user, email: email)
+
+      user = User.find_active_user_by_email(email)
+
+      expect(user.group_names_list).to include user.user_login_id
+    end
   end
 
-  it "should authenticate ms chap" do
-    user = create(:user)
-    totp = "757364"
-    challenge_string = "ee85e142eadfec52"
-    response_string = "0392a9e43edee3129f735b37fd9d0b0d3f66aa7a00f35440"
+  describe '.valid_domain?' do
+    it 'should check valid hosted domain' do
+      allow(ENV).to receive(:[]).with('GATE_HOSTED_DOMAINS').and_return('alfa.com,beta.com')
+      expect(User.valid_domain?('alfa.com')).to be true
+      expect(User.valid_domain?('beta.com')).to be true
+      expect(User.valid_domain?('gama.com')).to be false
 
-    expect(user.authenticate_ms_chap(totp, challenge_string, response_string)).to eq("NT_KEY: 57247E8BAD1959F9544B2C5057F77AD8")
-    expect(user.authenticate_ms_chap("78787", challenge_string, response_string)).to eq("NT_STATUS_UNSUCCESSFUL: Failure (0xC0000001)")
+      allow(ENV).to receive(:[]).with('GATE_HOSTED_DOMAINS').and_return('')
+      expect(User.valid_domain?('alfa.com')).to be false
+    end
   end
 
-  it "should authenticate ms chap with drift" do
-    user = create(:user)
-    challenge_string = "ee85e142eadfec52"
-    response_string = "0392a9e43edee3129f735b37fd9d0b0d3f66aa7a00f35440"
+  describe '.ms_chap_auth' do
+    it 'should authenticate ms chap' do
+      user = create(:user)
+      vpn = Vpn.create(name: :X, ip_address: '10.240.0.1' )
+      user.groups.first.vpns << vpn
+      params = {}
+      params[:addresses] = '10.240.0.1'
+      params[:user] = user.user_login_id
+      params[:challenge] = 'ee85e142eadfec52'
+      params[:response] = '0392a9e43edee3129f735b37fd9d0b0d3f66aa7a00f35440'
+      allow_any_instance_of(User).to receive(:get_user_otp_at).and_return('757364')
 
-    totp = ["757364", "123456", "876543"]
-    expect(user.authenticate_ms_chap_with_drift(totp, challenge_string, response_string)).to eq("NT_KEY: 57247E8BAD1959F9544B2C5057F77AD8")
-
-    totp = ["123456", "757364", "876543"]
-    expect(user.authenticate_ms_chap_with_drift(totp, challenge_string, response_string)).to eq("NT_KEY: 57247E8BAD1959F9544B2C5057F77AD8")
-
-    totp = ["123456", "876543", "757364"]
-    expect(user.authenticate_ms_chap_with_drift(totp, challenge_string, response_string)).to eq("NT_KEY: 57247E8BAD1959F9544B2C5057F77AD8")
-
-    expect(user.authenticate_ms_chap_with_drift(["78787", "121212", "545454"], challenge_string, response_string)).to eq("NT_STATUS_UNSUCCESSFUL: Failure (0xC0000001)")
-  end
-
-  it "should authenticate ms chap" do
-    user = create(:user)
-    vpn = Vpn.create(name: :"X", ip_address: "10.240.0.1" )
-    user.groups.first.vpns << vpn
-    params = {}
-    params[:addresses] = "10.240.0.1"
-    params[:user] = user.user_login_id
-    params[:challenge] = "ee85e142eadfec52"
-    params[:response] = "0392a9e43edee3129f735b37fd9d0b0d3f66aa7a00f35440"
-
-    allow_any_instance_of(User).to receive(:get_user_otp_at).and_return("757364")
-
-    expect(User.ms_chap_auth(params)).to eq("NT_KEY: 57247E8BAD1959F9544B2C5057F77AD8")
-  end
-
-  it "should return different otps for different times" do
-    user = create(:user)
-    user.auth_key = ROTP::Base32.random_base32
-
-    drift_interval = 30
-    t = Time.now
-    otp1 = user.get_user_otp_at(t)
-    otp2 = user.get_user_otp_at(t - drift_interval)
-    otp3 = user.get_user_otp_at(t + drift_interval)
-
-    expect(otp1).to_not equal(otp2)
-    expect(otp2).to_not equal(otp3)
-    expect(otp3).to_not equal(otp1)
+      expect(User.ms_chap_auth(params)).to eq('NT_KEY: 57247E8BAD1959F9544B2C5057F77AD8')
+    end
   end
 
   describe '.get_user_pass_attributes' do
-    it 'should return token and email if token and email is passed' do
-      params = { email: Faker::Internet.email, token: SecureRandom.uuid, user: '', password: '' }
-      expect(User.get_user_pass_attributes(params)).to eq([params[:email], params[:token]])
+    context 'token and email is passed' do
+      it 'should return token and email' do
+        params = { email: Faker::Internet.email, token: SecureRandom.uuid, user: '', password: '' }
+        expect(User.get_user_pass_attributes(params)).to eq([params[:email], params[:token]])
+      end
     end
 
-    it 'should return password and email if email and password is present, and token is not present' do
-      params = { email: Faker::Internet.email, token: '', user: '', password: SecureRandom.uuid }
-      expect(User.get_user_pass_attributes(params)).to eq([params[:email], params[:password]])
+    context 'email and password is present, and token is not present' do
+      it 'should return password and email' do
+        params = { email: Faker::Internet.email, token: '', user: '', password: SecureRandom.uuid }
+        expect(User.get_user_pass_attributes(params)).to eq([params[:email], params[:password]])
+      end
     end
 
-    it 'should return user and token if user and token is present, and email is not present' do
-      params = { email: '', token: SecureRandom.uuid, user: Faker::Internet.email, password: '' }
-      expect(User.get_user_pass_attributes(params)).to eq([params[:user], params[:token]])
+    context 'user and token is present, and email is not present' do
+      it 'should return user and token' do
+        params = { email: '', token: SecureRandom.uuid, user: Faker::Internet.email, password: '' }
+        expect(User.get_user_pass_attributes(params)).to eq([params[:user], params[:token]])
+      end
     end
 
-    it 'should return user and password if user and password is present and email and token is not present' do
-      params = { email: '', token: '', user: Faker::Internet.email, password: SecureRandom.uuid }
-      expect(User.get_user_pass_attributes(params)).to eq([params[:user], params[:password]])
+    context 'user and password is present and email and token is not present' do
+      it 'should return user and password' do
+        params = { email: '', token: '', user: Faker::Internet.email, password: SecureRandom.uuid }
+        expect(User.get_user_pass_attributes(params)).to eq([params[:user], params[:password]])
+      end
     end
 
-    it 'should return nil and nil if email and user is blank or password and token is blank' do
-      params = { email: '', token: '', user: '', password: '' }
-      expect(User.get_user_pass_attributes(params)).to eq([nil, nil])
+    context 'email and user is blank or password and token is blank' do
+      it 'should return nil and nil' do
+        params = { email: '', token: '', user: '', password: '' }
+        expect(User.get_user_pass_attributes(params)).to eq([nil, nil])
+      end
     end
   end
 
@@ -553,11 +577,11 @@ RSpec.describe User, type: :model do
     end
 
     context 'when two users exist with same login_id' do
-      let(:user_login_id) {'same-id'}
-      subject(:user) {User.get_user(user_login_id)}
+      let(:user_login_id) { 'same-id' }
+      subject(:user) { User.get_user(user_login_id) }
 
-      let(:first_user) {build(:user, user_login_id: user_login_id, name: 'Test1', email: "#{user_login_id}@test.com")}
-      let(:second_user) {build(:user, user_login_id: user_login_id, name: 'Test2', email: "#{user_login_id}@aux.test.com")}
+      let(:first_user) { build(:user, user_login_id: user_login_id, name: 'Test1', email: "#{user_login_id}@test.com") }
+      let(:second_user) { build(:user, user_login_id: user_login_id, name: 'Test2', email: "#{user_login_id}@aux.test.com") }
 
       it 'returns first found active user' do
         first_user.save
@@ -578,18 +602,21 @@ RSpec.describe User, type: :model do
   end
 
   describe '.add_user' do
-
     it 'creates a new user' do
       user_data = build(:user)
       domain = user_data.email.split('@').last
+
       user = User.add_user(user_data.first_name, user_data.last_name, user_data.user_role, domain)
+
       expect(user.persisted?).to eq(true)
     end
 
     it 'creates a user with email in format first_name.last_name' do
       user_data = build(:user)
       domain = user_data.email.split('@').last
+
       user = User.add_user(user_data.first_name, user_data.last_name, user_data.user_role, domain)
+
       expect(user.persisted?).to eq(true)
       expect(user.email).to eq("#{user.first_name.downcase}.#{user.last_name.downcase}@#{domain}")
     end
@@ -597,34 +624,44 @@ RSpec.describe User, type: :model do
     it 'generate uid' do
       user_data = build(:user)
       domain = user_data.email.split('@').last
+
       expect_any_instance_of(User).to receive(:generate_uid)
+
       User.add_user(user_data.first_name, user_data.last_name, user_data.user_role, domain)
     end
 
     it 'generates login id' do
       user_data = build(:user)
       domain = user_data.email.split('@').last
+
       user = User.add_user(user_data.first_name, user_data.last_name, user_data.user_role, domain)
+
       expect(user.user_login_id).to eq("#{user_data.first_name.downcase}.#{user_data.last_name.downcase}")
     end
 
     it 'initializes host groups' do
       user_data = build(:user)
       domain = user_data.email.split('@').last
+
       expect_any_instance_of(User).to receive(:initialise_host_and_group)
+
       User.add_user(user_data.first_name, user_data.last_name, user_data.user_role, domain)
     end
 
     xit 'fails if required fields are not present' do
       user_data = build(:user)
       domain = user_data.email.split('@').last
+
       user = User.add_user('', user_data.last_name, user_data.user_role, domain)
+
       expect(user.persisted?).to eq(false)
     end
 
     xit 'fails if domain doesn\'t exist in list of domains' do
       user_data = build(:user)
+
       user = User.add_user(user_data.first_name, user_data.last_name, user_data.user_role, Faker::Internet.domain_name)
+
       expect(user.persisted?).to eq(false)
     end
 
@@ -632,8 +669,26 @@ RSpec.describe User, type: :model do
       user_data = build(:user)
       domain = user_data.email.split('@').last
       user_data.save
+
       user = User.add_user(user_data.first_name, user_data.last_name, user_data.user_role, domain)
+
       expect(user.persisted?).to eq(false)
+    end
+  end
+
+  describe '.check_email_address' do
+    it 'should check valid email address' do
+      email_address = 'satrya@gmail.com'
+      expect(User.check_email_address(email_address)).to eq(true)
+
+      email_address = 'satraya @gmail.com'
+      expect(User.check_email_address(email_address)).to eq(false)
+
+      email_address = 'satraya@-gmail.com'
+      expect(User.check_email_address(email_address)).to eq(false)
+
+      email_address = 'sat*raya@gmail.com'
+      expect(User.check_email_address(email_address)).to eq(false)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -224,6 +224,15 @@ RSpec.describe User, type: :model do
       expect(user.public_key).to eq(attrs[:public_key])
     end
 
+    it 'should update the public_key' do
+      rsa_key = OpenSSL::PKey::RSA.new(2048)
+      public_key = rsa_key.public_key.to_pem
+
+      user.update_profile(public_key: public_key)
+
+      expect(user.public_key).to eq(public_key)
+    end
+
     it 'should update user profile only for public_key, name, product_name, admin and active' do
       auth_key = ROTP::Base32.random_base32
       user.update_profile(auth_key: auth_key)
@@ -282,14 +291,6 @@ RSpec.describe User, type: :model do
   context ".update_profile" do
     before(:each) do
       @user = create(:user)
-    end
-    it "should update the public_key" do
-      require 'openssl'
-      rsa_key = OpenSSL::PKey::RSA.new(2048)
-      public_key = rsa_key.public_key.to_pem
-      @user.update_profile({ 'public_key' => public_key })
-      @user = User.find(@user.id)
-      expect(@user.public_key).to eq(public_key)
     end
 
     it "should update the name" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -324,6 +324,14 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#uid' do
+    it 'should check uid creation with offset' do
+      user = create(:user)
+
+      expect(user.uid.to_i).to eq(user.id + uid_constant)
+    end
+  end
+
   describe '.check_email_address' do
     it 'should check valid email address' do
       email_address = 'satrya@gmail.com'
@@ -346,11 +354,6 @@ RSpec.describe User, type: :model do
 
   before(:each) do
     create(:group)
-  end
-
-  it "should check uid creation with offset" do
-    user = create(:user)
-    expect(user.uid.to_i).to eq(user.id + UID_CONSTANT)
   end
 
   it "should return false if user is not active" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -462,7 +462,7 @@ RSpec.describe User, type: :model do
     it 'should return response with pw_name equal user_login_id' do
       user = create(:user)
 
-      response = User.get_passwd_uid_response user
+      response = user.get_passwd_uid_response user
 
       expect(response[:pw_name]).to eq(user.user_login_id)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -332,6 +332,16 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '.get_shadow_name_response' do
+    it 'should return response with sp_namp equal user_login_id' do
+      user = create(:user)
+
+      response = User.get_shadow_name_response user.name
+
+      expect(response[:sp_namp]).to eq(user.user_login_id)
+    end
+  end
+
   describe '.check_email_address' do
     it 'should check valid email address' do
       email_address = 'satrya@gmail.com'
@@ -354,12 +364,6 @@ RSpec.describe User, type: :model do
 
   before(:each) do
     create(:group)
-  end
-
-  it "should return false if user is not active" do
-    user = create(:user)
-    response = User.get_shadow_name_response user.name
-    expect(response[:sp_namp]).to eq(user.user_login_id)
   end
 
   it "should return false if user is not active" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -703,6 +703,25 @@ RSpec.describe User, type: :model do
         end
       end
     end
+
+    context 'given user which does not belongs to group name equal to user_login_id' do
+      before(:each) do
+        GroupAssociation.where(user_id: user.id).delete_all
+      end
+
+      it 'should return correct response with nil pw_gid' do
+        sysadmins = User.get_sysadmins [user.id]
+        expect(sysadmins.first).to satisfy do |sysadmin|
+          !sysadmin[:pw_name].nil? &&
+            !sysadmin[:pw_passwd].nil? &&
+            !sysadmin[:pw_uid].nil? &&
+            sysadmin[:pw_gid].nil? &&
+            !sysadmin[:pw_gecos].nil? &&
+            !sysadmin[:pw_dir].nil? &&
+            !sysadmin[:pw_shell].nil?
+        end
+      end
+    end
   end
 
   describe '.check_email_address' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -678,21 +678,23 @@ RSpec.describe User, type: :model do
 
   describe '.get_sysadmins' do
     let(:user) { create(:user) }
-    it 'should return correct amount of sysadmins' do
-      sysadmins = User.get_sysadmins [user.id]
-      expect(sysadmins.size).to eq 1
-    end
+    context 'given user belongs to group name equal to user_login_id' do
+      it 'should return correct amount of sysadmins' do
+        sysadmins = User.get_sysadmins [user.id]
+        expect(sysadmins.size).to eq 1
+      end
 
-    it 'should include intended sysadmin' do
-      sysadmins = User.get_sysadmins [user.id]
-      pw_name_sysadmins = sysadmins.map { |sysadmin| sysadmin[:pw_name] }
-      expect(pw_name_sysadmins).to include user.user_login_id
-    end
+      it 'should include intended sysadmin' do
+        sysadmins = User.get_sysadmins [user.id]
+        pw_name_sysadmins = sysadmins.map { |sysadmin| sysadmin[:pw_name] }
+        expect(pw_name_sysadmins).to include user.user_login_id
+      end
 
-    it 'should not included nil on pw_gid' do
-      sysadmins = User.get_sysadmins [user.id]
-      pw_gid_sysadmins = sysadmins.map { |sysadmin| sysadmin[:pw_gid] }
-      expect(pw_gid_sysadmins).not_to include nil
+      it 'should not included nil on pw_gid' do
+        sysadmins = User.get_sysadmins [user.id]
+        pw_gid_sysadmins = sysadmins.map { |sysadmin| sysadmin[:pw_gid] }
+        expect(pw_gid_sysadmins).not_to include nil
+      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -342,6 +342,16 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '.get_passwd_uid_response' do
+    it 'should return response with pw_name equal user_login_id' do
+      user = create(:user)
+
+      response = User.get_passwd_uid_response user
+
+      expect(response[:pw_name]).to eq(user.user_login_id)
+    end
+  end
+
   describe '.check_email_address' do
     it 'should check valid email address' do
       email_address = 'satrya@gmail.com'
@@ -364,12 +374,6 @@ RSpec.describe User, type: :model do
 
   before(:each) do
     create(:group)
-  end
-
-  it "should return false if user is not active" do
-    user = create(:user)
-    response = User.get_passwd_uid_response user
-    expect(response[:pw_name]).to eq(user.user_login_id)
   end
 
   it "should get all users for passwd" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -249,6 +249,12 @@ RSpec.describe User, type: :model do
       expect(user.public_key).to eq(public_key)
     end
 
+    it 'should set deactivation time when user is deactivated' do
+      user.update_profile(active: false)
+
+      expect(user.deactivated_at).not_to be nil
+    end
+
     it 'should update user profile only for public_key, name, product_name, admin and active' do
       auth_key = ROTP::Base32.random_base32
       user.update_profile(auth_key: auth_key)
@@ -302,12 +308,6 @@ RSpec.describe User, type: :model do
 
   before(:each) do
     create(:group)
-  end
-
-  it "should set deactivation time when user is deactivated" do
-    user = create(:user)
-    user.update_profile(active: false)
-    expect(user.deactivated_at).not_to be nil
   end
 
   describe ".purge!" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -722,6 +722,13 @@ RSpec.describe User, type: :model do
         end
       end
     end
+
+    context 'given nonexistant user' do
+      it 'should return zero amount of sysadmins' do
+        sysadmins = User.get_sysadmins [0]
+        expect(sysadmins.size).to eq 0
+      end
+    end
   end
 
   describe '.check_email_address' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -275,6 +275,19 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#purge!' do
+    let(:user) { create(:user) }
+    it 'should remove group associations for inactive user' do
+      create(:user)
+      user.update!(active: false)
+
+      user.purge!
+
+      user.reload
+      expect(user.group_associations.length).to eq 0
+    end
+  end
+
   describe '#update' do
     context 'deactivate admin user' do
       it 'should revoke admin status' do
@@ -311,15 +324,6 @@ RSpec.describe User, type: :model do
   end
 
   describe ".purge!" do
-    it "should remove group associations for inactive user" do
-      create(:user)
-      user = create(:user)
-      user.update!(active: false)
-      user.purge!
-      user.reload
-      expect(user.group_associations.length).to eq 0
-    end
-
     it "should NOT remove group associations for active user" do
       user = create(:user)
       user.purge!

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -286,6 +286,15 @@ RSpec.describe User, type: :model do
       user.reload
       expect(user.group_associations.length).to eq 0
     end
+
+    it 'should NOT remove group associations for active user' do
+      create(:user)
+
+      user.purge!
+
+      user.reload
+      expect(user.group_associations.length).not_to eq 0
+    end
   end
 
   describe '#update' do
@@ -321,15 +330,6 @@ RSpec.describe User, type: :model do
 
   before(:each) do
     create(:group)
-  end
-
-  describe ".purge!" do
-    it "should NOT remove group associations for active user" do
-      user = create(:user)
-      user.purge!
-      user.reload
-      expect(user.group_associations.length).not_to eq 0
-    end
   end
 
   it "should check valid email address" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -448,16 +448,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#get_passwd_uid_response' do
-    it 'should return response with pw_name equal user_login_id' do
-      user = create(:user)
-
-      response = user.get_passwd_uid_response
-
-      expect(response[:pw_name]).to eq(user.user_login_id)
-    end
-  end
-
   describe '.get_shadow_name_response' do
     it 'should return response with sp_namp equal user_login_id' do
       user = create(:user)


### PR DESCRIPTION
When not responding to gid on `respond_to?(:gid) && gid` because gid is actually nil.

The checking goes to `user_hash[:pw_gid] = groups.where(name: user_login_id).first.gid if groups.where(name: user_login_id).count > 0` which will call query to count over and over even though the result is 0 (this is why gid is nil).

Add a query to count the number of gid in the previous step to make sure the program doesn't search the gid by telling that the gid count is actually 0.

@giosakti 