### PR TITLE
Api add user to group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- API to add user to group (POST /api/v1/groups/:group_id/users)
 
 ## [1.1.3] - 2019-09-17
 ### Changed

--- a/api_blueprint/group.apib
+++ b/api_blueprint/group.apib
@@ -178,10 +178,15 @@ Create new group
 
 + Request (application/json)
 
-        {
-            "user_id": 7,
-            "access_token": "user-token",
-            "expiration_date": "2019-11-20"
-        }
+    + Header
+
+            Authorization: <user-token>
+
+    + Body
+
+            {
+                "user_id": 7,
+                "expiration_date": "2019-11-20"
+            }
 
 + Response 204

--- a/api_blueprint/group.apib
+++ b/api_blueprint/group.apib
@@ -164,3 +164,22 @@ Create new group
             transfer-encoding: chunked
 
     + Body
+
+# Group Users [/api/v1/groups/{group_id}/users]
+
++ Parameters
+    + group_id: 1 (required, number) - ID of the Group in form of an integer
+
+## Add user [POST]
+
++ user_id (required, number) - ID of the User in form of an integer
++ access_token (required, string) - Token of acting user (Require user with admin or group admin level)
+
++ Request (application/json)
+
+        {
+            "user_id": 7,
+            "access_token": "user-token"
+        }
+
++ Response 204

--- a/api_blueprint/group.apib
+++ b/api_blueprint/group.apib
@@ -173,7 +173,6 @@ Create new group
 ## Add user [POST]
 
 + user_id (required, number) - ID of the User in form of an integer
-+ access_token (required, string) - Token of acting user (Require user with admin or group admin level)
 + expiration_date (optional, date) - Membership expiration date in format (YYYY-MM-DD)
 
 + Request (application/json)

--- a/api_blueprint/group.apib
+++ b/api_blueprint/group.apib
@@ -174,12 +174,14 @@ Create new group
 
 + user_id (required, number) - ID of the User in form of an integer
 + access_token (required, string) - Token of acting user (Require user with admin or group admin level)
++ expiration_date (optional, date) - Membership expiration date in format (YYYY-MM-DD)
 
 + Request (application/json)
 
         {
             "user_id": 7,
-            "access_token": "user-token"
+            "access_token": "user-token",
+            "expiration_date": "2019-11-20"
         }
 
 + Response 204

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -27,9 +27,9 @@ class ::Api::V1::GroupsController < ::Api::V1::BaseController
   end
 
   def add_user
-    return raise_unauthorized unless current_user.admin?
-
     @group = Group.find_by(id: params[:id])
+    return raise_unauthorized unless current_user.admin? || @group.admin?(current_user)
+
     @group.add_user params[:user_id]
     head :no_content
   end

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -28,6 +28,8 @@ class ::Api::V1::GroupsController < ::Api::V1::BaseController
 
   def add_user
     @group = Group.find_by(id: params[:id])
+    return head :not_found unless @group.present?
+
     return raise_unauthorized unless current_user.admin? || @group.admin?(current_user)
 
     @group.add_user params[:user_id]

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -27,11 +27,11 @@ class ::Api::V1::GroupsController < ::Api::V1::BaseController
   end
 
   def add_user
-    if current_user.admin?
-      @group = Group.find_by(id: params[:id])
-      @group.add_user params[:user_id]
-      head :no_content
-    end
+    return raise_unauthorized unless current_user.admin?
+
+    @group = Group.find_by(id: params[:id])
+    @group.add_user params[:user_id]
+    head :no_content
   end
 
   private

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -27,6 +27,8 @@ class ::Api::V1::GroupsController < ::Api::V1::BaseController
   end
 
   def add_user
+    @group = Group.find_by(id: params[:id])
+    @group.add_user params[:user_id]
     head :no_content
   end
 

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -27,9 +27,11 @@ class ::Api::V1::GroupsController < ::Api::V1::BaseController
   end
 
   def add_user
-    @group = Group.find_by(id: params[:id])
-    @group.add_user params[:user_id]
-    head :no_content
+    if current_user.admin?
+      @group = Group.find_by(id: params[:id])
+      @group.add_user params[:user_id]
+      head :no_content
+    end
   end
 
   private

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -26,6 +26,10 @@ class ::Api::V1::GroupsController < ::Api::V1::BaseController
     end
   end
 
+  def add_user
+    head :no_content
+  end
+
   private
 
   def group_params

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -35,7 +35,8 @@ class ::Api::V1::GroupsController < ::Api::V1::BaseController
     user = User.find_by(id: params[:user_id])
     return head :unprocessable_entity unless user.present?
 
-    @group.add_user params[:user_id]
+    expiration_date = params[:expiration_date]
+    @group.add_user_with_expiration(params[:user_id], expiration_date)
     head :no_content
   end
 

--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -32,6 +32,9 @@ class ::Api::V1::GroupsController < ::Api::V1::BaseController
 
     return raise_unauthorized unless current_user.admin? || @group.admin?(current_user)
 
+    user = User.find_by(id: params[:user_id])
+    return head :unprocessable_entity unless user.present?
+
     @group.add_user params[:user_id]
     head :no_content
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,12 +86,9 @@ Rails.application.routes.draw do
       post 'users/profile' => 'users#update', format: :json, :constraints => { format: 'json' }
       post 'endpoints' => 'endpoints#create', format: :json, :constraints => { format: 'json' }
       post 'endpoints/:id/add_group' => 'endpoints#add_group', format: :json, constraints: { format: 'json' }
+      post 'groups/:id/users' => 'groups#add_user', format: :json, constraints: { format: 'json' }
 
-      resources :groups, only: [:create], format: :json do
-        member do
-          post 'add_user'
-        end
-      end
+      resources :groups, only: [:create], format: :json
       resources :vpns, only: [:create], format: :json do
         member do
           post 'assign_group'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,7 +87,11 @@ Rails.application.routes.draw do
       post 'endpoints' => 'endpoints#create', format: :json, :constraints => { format: 'json' }
       post 'endpoints/:id/add_group' => 'endpoints#add_group', format: :json, constraints: { format: 'json' }
 
-      resources :groups, only: [:create], format: :json
+      resources :groups, only: [:create], format: :json do
+        member do
+          post 'add_user'
+        end
+      end
       resources :vpns, only: [:create], format: :json do
         member do
           post 'assign_group'

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -53,4 +53,23 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
       end
     end
   end
+
+  describe '#add_user' do
+    before(:each) do
+      @group = create(:group)
+    end
+    context 'authenticated as admin' do
+      context 'valid user id' do
+        it 'should return proper response' do
+          new_user = create(:user, admin: false)
+          post :add_user, params: {
+            id: @group.id,
+            user_id: new_user.id,
+            access_token: @token,
+          }
+          expect(response.status).to eq 204
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -81,5 +81,17 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
         end
       end
     end
+
+    context 'unauthenticated' do
+      it 'should return 401 http status' do
+        new_user = create(:user, admin: false)
+        post :add_user, params: {
+          id: @group.id,
+          user_id: new_user.id,
+          access_token: 'foo',
+        }
+        expect(response.status).to eq 401
+      end
+    end
   end
 end

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -64,6 +64,20 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
       @group = create(:group)
       @new_user = create(:user, admin: false)
     end
+
+    context 'invalid param' do
+      context 'group id not found' do
+        it 'should return 404' do
+          post :add_user, params: {
+            id: 666,
+            user_id: @new_user.id,
+            access_token: @admin_token,
+          }
+          expect(response.status).to eq 404
+        end
+      end
+    end
+
     context 'authenticated as admin' do
       context 'valid user id' do
         it 'should return proper response' do

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe ::Api::V1::GroupsController, type: :controller do
-  let(:valid_attributes) {
-    {name: 'jumbo'}
-  }
+  let(:valid_attributes) do
+    { name: 'jumbo' }
+  end
 
   before(:each) do
     @user = build(:user)
@@ -12,18 +12,18 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
     @token = @user.access_token.token
   end
 
-  describe 'Authenticated' do
-    describe 'Create Group' do
+  describe '#create' do
+    context 'authenticated as admin' do
       context 'with valid_attributes' do
         it 'should create groups' do
-          post :create,  params: {group: valid_attributes, access_token: @token}
+          post :create, params: { group: valid_attributes, access_token: @token }
           group = Group.where(name: valid_attributes[:name]).first
           expect(group.blank?).to eq(false)
           expect(group.name).to eq(valid_attributes[:name])
         end
 
         it 'should return proper response' do
-          post :create,  params: {group: valid_attributes, access_token: @token}
+          post :create, params: { group: valid_attributes, access_token: @token }
           expect(response.status).to eq(200)
           group = Group.where(name: valid_attributes[:name]).first
           obj = JSON.parse(response.body)
@@ -35,9 +35,9 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
       context 'group already exist' do
         it 'should return existing group id' do
           existing_group = create(:group, name: valid_attributes[:name])
-          post :create,  params: {group: valid_attributes, access_token: @token}
+          post :create,  params: { group: valid_attributes, access_token: @token }
           expect(response.status).to eq(422)
-          expect(response.body).to eq({ 
+          expect(response.body).to eq({
             status: 'group already exist',
             id: existing_group.id,
             name: existing_group.name,
@@ -45,12 +45,12 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
         end
       end
     end
-  end
 
-  describe 'Unauthenticated' do
-    it 'gives 401 when access token is invalid' do
-      post :create,  params: {group: valid_attributes, access_token: 'foo'}
-      expect(response.status).to eq(401)
+    context 'unauthenticated' do
+      it 'should return 401 http status' do
+        post :create, params: { group: valid_attributes, access_token: 'foo' }
+        expect(response.status).to eq(401)
+      end
     end
   end
 end

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -67,13 +67,24 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
 
     context 'invalid param' do
       context 'group id not found' do
-        it 'should return 404' do
+        it 'should return 404 http status' do
           post :add_user, params: {
             id: 666,
             user_id: @new_user.id,
             access_token: @admin_token,
           }
           expect(response.status).to eq 404
+        end
+      end
+
+      context 'invalid user id' do
+        it 'should return 422 http status' do
+          post :add_user, params: {
+            id: @group.id,
+            user_id: 'rand',
+            access_token: @admin_token,
+          }
+          expect(response.status).to eq 422
         end
       end
     end

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -95,6 +95,15 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
         }
         expect(@group.users).to be_empty
       end
+
+      it 'should return 401 http status' do
+        post :add_user, params: {
+          id: @group.id,
+          user_id: @new_user.id,
+          access_token: @user_token,
+        }
+        expect(response.status).to eq 401
+      end
     end
 
     context 'unauthenticated' do

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
     end
 
     context 'authenticated as admin' do
-      context 'valid user id' do
+      context 'valid param' do
         it 'should return proper response' do
           post :add_user, params: {
             id: @group.id,
@@ -107,6 +107,17 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
             access_token: @admin_token,
           }
           expect(@group.users).to contain_exactly @new_user
+        end
+
+        it 'should set membership expiration date' do
+          post :add_user, params: {
+            id: @group.id,
+            user_id: @new_user.id,
+            expiration_date: '2019-10-10',
+            access_token: @admin_token,
+          }
+          membership = @group.group_associations.find_by(user_id: @new_user.id)
+          expect(membership.expiration_date).to eq Date.parse('2019-10-10')
         end
       end
     end

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -57,37 +57,35 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
   describe '#add_user' do
     before(:each) do
       @group = create(:group)
+      @new_user = create(:user, admin: false)
     end
     context 'authenticated as admin' do
       context 'valid user id' do
         it 'should return proper response' do
-          new_user = create(:user, admin: false)
           post :add_user, params: {
             id: @group.id,
-            user_id: new_user.id,
+            user_id: @new_user.id,
             access_token: @token,
           }
           expect(response.status).to eq 204
         end
 
         it 'should add user to group' do
-          new_user = create(:user, admin: false)
           post :add_user, params: {
             id: @group.id,
-            user_id: new_user.id,
+            user_id: @new_user.id,
             access_token: @token,
           }
-          expect(@group.users).to contain_exactly new_user
+          expect(@group.users).to contain_exactly @new_user
         end
       end
     end
 
     context 'unauthenticated' do
       it 'should return 401 http status' do
-        new_user = create(:user, admin: false)
         post :add_user, params: {
           id: @group.id,
-          user_id: new_user.id,
+          user_id: @new_user.id,
           access_token: 'foo',
         }
         expect(response.status).to eq 401

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -6,24 +6,24 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
   end
 
   before(:each) do
-    @user = build(:user)
-    @user.access_token = build(:access_token)
-    @user.save
-    @token = @user.access_token.token
+    @admin = build(:admin_user)
+    @admin.access_token = build(:access_token)
+    @admin.save
+    @admin_token = @admin.access_token.token
   end
 
   describe '#create' do
     context 'authenticated as admin' do
       context 'with valid_attributes' do
         it 'should create groups' do
-          post :create, params: { group: valid_attributes, access_token: @token }
+          post :create, params: { group: valid_attributes, access_token: @admin_token }
           group = Group.where(name: valid_attributes[:name]).first
           expect(group.blank?).to eq(false)
           expect(group.name).to eq(valid_attributes[:name])
         end
 
         it 'should return proper response' do
-          post :create, params: { group: valid_attributes, access_token: @token }
+          post :create, params: { group: valid_attributes, access_token: @admin_token }
           expect(response.status).to eq(200)
           group = Group.where(name: valid_attributes[:name]).first
           obj = JSON.parse(response.body)
@@ -35,7 +35,7 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
       context 'group already exist' do
         it 'should return existing group id' do
           existing_group = create(:group, name: valid_attributes[:name])
-          post :create,  params: { group: valid_attributes, access_token: @token }
+          post :create,  params: { group: valid_attributes, access_token: @admin_token }
           expect(response.status).to eq(422)
           expect(response.body).to eq({
             status: 'group already exist',
@@ -65,7 +65,7 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
           post :add_user, params: {
             id: @group.id,
             user_id: @new_user.id,
-            access_token: @token,
+            access_token: @admin_token,
           }
           expect(response.status).to eq 204
         end
@@ -74,7 +74,7 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
           post :add_user, params: {
             id: @group.id,
             user_id: @new_user.id,
-            access_token: @token,
+            access_token: @admin_token,
           }
           expect(@group.users).to contain_exactly @new_user
         end

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -106,6 +106,20 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
       end
     end
 
+    context 'authenticated as group admin' do
+      before(:each) do
+        @group.add_admin @user
+      end
+      it 'should add user to group' do
+        post :add_user, params: {
+          id: @group.id,
+          user_id: @new_user.id,
+          access_token: @user_token,
+        }
+        expect(@group.users).to contain_exactly @new_user
+      end
+    end
+
     context 'unauthenticated' do
       it 'should return 401 http status' do
         post :add_user, params: {

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
     @admin.access_token = build(:access_token)
     @admin.save
     @admin_token = @admin.access_token.token
+
+    @user = build(:user, admin: false)
+    @user.access_token = build(:access_token)
+    @user.save
+    @user_token = @user.access_token.token
   end
 
   describe '#create' do
@@ -78,6 +83,17 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
           }
           expect(@group.users).to contain_exactly @new_user
         end
+      end
+    end
+
+    context 'authenticated as non admin' do
+      it 'should not add user to group' do
+        post :add_user, params: {
+          id: @group.id,
+          user_id: @new_user.id,
+          access_token: @user_token,
+        }
+        expect(@group.users).to be_empty
       end
     end
 

--- a/spec/controllers/api/v1/groups_controller_spec.rb
+++ b/spec/controllers/api/v1/groups_controller_spec.rb
@@ -69,6 +69,16 @@ RSpec.describe ::Api::V1::GroupsController, type: :controller do
           }
           expect(response.status).to eq 204
         end
+
+        it 'should add user to group' do
+          new_user = create(:user, admin: false)
+          post :add_user, params: {
+            id: @group.id,
+            user_id: new_user.id,
+            access_token: @token,
+          }
+          expect(@group.users).to contain_exactly new_user
+        end
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
     name { "#{first_name} #{last_name}" }
     active { true }
     admin { true }
-    sequence(:reset_password_token) { |n| "secret#{n}" }
+    sequence(:reset_password_token) { |n| "user_secret#{n}" }
     after(:create) do |user, _evaluator|
       user.assign_attributes(
         user_login_id: user.generate_login_id, uid: user.generate_uid


### PR DESCRIPTION
Add API to add a user to a group. This action can only be done by Gate admin or the admin of the group.