### PR TITLE
Added id to be returned in user get request

### DIFF
--- a/api_blueprint/user.apib
+++ b/api_blueprint/user.apib
@@ -135,6 +135,7 @@ Get user data with email, uid or username
 
             {
                 "email": "bar@test.com",
+                "id": null,
                 "uid": null,
                 "name": "foo",
                 "active": true,

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -15,7 +15,7 @@ class ::Api::V1::UsersController < ::Api::V1::BaseController
   def show
     if @user.present?
       user_attrs = %w(
-        email uid name active admin home_dir shell public_key user_login_id
+        email id uid name active admin home_dir shell public_key user_login_id
         product_name
       )
       data = @user.attributes.select { |k, _v| user_attrs.include?(k) }


### PR DESCRIPTION
The`API is /api/v1/users/profile` endpoint is returning `uid` of the user while the `/api/v1/group/{:group_id}/users` uses the id of the user. Hence we are unable to use the `uid` obtained to add users into the groups. 

In https://github.com/gate-sso/gate/blob/master/app/models/user.rb,
Two ids are being used, but they are more or less related with each other. From our understanding of the implementation of `generate_uid(uid_buffer=5000)`. However, from trying out different emails we realized that `uid` and `id` do not always have the same difference of 5000 (so we are unable to do a simple subtraction to obtain the required id.
