### PR TITLE
Use active record to store session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Store session to db using active record instead of using cookies
 
 ## [1.1.5] - 2019-10-20
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'activerecord-session_store'
 gem 'ansi', '~> 1.5.0'
 gem 'bootstrap', '~> 4.3.1'
 gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,12 @@ GEM
       activemodel (= 5.1.6.2)
       activesupport (= 5.1.6.2)
       arel (~> 8.0)
+    activerecord-session_store (1.1.3)
+      actionpack (>= 4.0)
+      activerecord (>= 4.0)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 1.5.2, < 3)
+      railties (>= 4.0)
     activesupport (5.1.6.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -370,6 +376,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-session_store
   ansi (~> 1.5.0)
   bootstrap (~> 4.3.1)
   capybara

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,8 +3,6 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  def setup_user; end
-
   def render_404
     respond_to do |format|
       format.html { render file: "#{Rails.root}/public/404", layout: false, status: :not_found }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,8 +5,6 @@ class GroupsController < ApplicationController
                                      remove_admin delete_user delete_vpn delete_machine]
   before_action :authenticate_user!
 
-  prepend_before_action :setup_user if Rails.env.development?
-
   def index
     @groups = []
     @group_search = params[:group_search]

--- a/app/controllers/host_machines_controller.rb
+++ b/app/controllers/host_machines_controller.rb
@@ -1,7 +1,6 @@
 class HostMachinesController < ApplicationController
   before_action :set_paper_trail_whodunnit
   before_action :set_host_machine, only: %i[add_group show edit update destroy delete_group]
-  prepend_before_action :setup_user if Rails.env.development?
   before_action :authenticate_user!
   before_action :authorize_user, only: %i[delete_group update]
 

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -3,8 +3,7 @@ class ProfileController < ApplicationController
 
   before_action :set_paper_trail_whodunnit
   skip_before_action :verify_authenticity_token, if: Proc.new { |c| c.request.format == 'application/json' }
-  before_action :authenticate_user!, except: %i[user_id verify authenticate authenticate_cas authenticate_ms_chap authenticate_pam public_key] unless Rails.env.development?
-  prepend_before_action :setup_user if Rails.env.development?
+  before_action :authenticate_user!, except: %i[user_id verify authenticate authenticate_cas authenticate_ms_chap authenticate_pam public_key]
 
   def regen_auth
     current_user.generate_two_factor_auth(true)

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_gate_session'
+Rails.application.config.session_store :active_record_store, key: '_gate_session'

--- a/db/migrate/20200113065717_add_sessions_table.rb
+++ b/db/migrate/20200113065717_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, :null => false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, :unique => true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190820080624) do
+ActiveRecord::Schema.define(version: 20200113065717) do
 
   create_table "access_tokens", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "hashed_token"
@@ -152,6 +152,15 @@ ActiveRecord::Schema.define(version: 20190820080624) do
     t.datetime "updated_at", null: false
     t.index ["group_id"], name: "index_saml_app_configs_on_group_id"
     t.index ["organisation_id"], name: "index_saml_app_configs_on_organisation_id"
+  end
+
+  create_table "sessions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   create_table "users", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
Store session data to the database using active record instead of browser cookies.
This will prevent unauthorized user stole the cookies from the previous user or by sniffing requests.
Cookies will only contain session id, session data will be destroyed when user logout.