### PR TITLE
Fix paper trail when user removed from group

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -188,7 +188,7 @@ class Group < ApplicationRecord
   end
 
   def remove_user(user_id)
-    group_associations.where(user_id: user_id).delete_all
+    group_associations.where(user_id: user_id).destroy_all
     burst_host_cache
   end
 end

--- a/app/models/group_association.rb
+++ b/app/models/group_association.rb
@@ -4,6 +4,6 @@ class GroupAssociation < ApplicationRecord
   belongs_to :group
 
   def self.revoke_expired(date = Date.today)
-    where('expiration_date < ?', date).delete_all
+    where('expiration_date < ?', date).destroy_all
   end
 end

--- a/spec/models/group_association_spec.rb
+++ b/spec/models/group_association_spec.rb
@@ -1,19 +1,33 @@
+require 'rails_helper'
+
 describe GroupAssociation, type: :model do
   describe '.revoke_expired' do
-    it 'should revoke associations that expired yesterday' do
-      user = create(:user)
-      group = create(:group)
-      group.add_user_with_expiration(user, Date.today - 1)
+    let(:user) { create(:user) }
+    let(:group) { create(:group) }
 
-      GroupAssociation.revoke_expired
+    context 'when found expired associations' do
+      it 'should revoke associations' do
+        group.add_user_with_expiration(user, Date.today - 1)
 
-      expired_association = GroupAssociation.where('expiration_date < ?', Date.today).count
-      expect(expired_association).to eq 0
+        GroupAssociation.revoke_expired
+
+        expired_association = GroupAssociation.where('expiration_date < ?', Date.today).count
+        expect(expired_association).to eq 0
+      end
+
+      it 'should create paper trail with event destroy' do
+        group_association = group.add_user_with_expiration(user, Date.today - 1)
+
+        GroupAssociation.revoke_expired
+
+        versions = PaperTrail::Version.
+          with_item_keys(GroupAssociation.name, group_association.id).
+          where(event: 'destroy')
+        expect(versions.length).to eq(1)
+      end
     end
 
     it 'should not revoke associations that not expired yet' do
-      user = create(:user)
-      group = create(:group)
       group.add_user_with_expiration(user, Date.today)
 
       GroupAssociation.revoke_expired

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -114,6 +114,17 @@ RSpec.describe Group, type: :model do
       expect(group.users.map(&:id).include?(user.id)).to eq(false)
     end
 
+    it 'should create paper trail with event destroy' do
+      group.add_user(user.id)
+      group_association_id = group.group_associations.where(user_id: user.id).first.id
+      group.remove_user(user.id)
+
+      versions = PaperTrail::Version.
+        with_item_keys(GroupAssociation.name, group_association_id).
+        where(event: 'destroy')
+      expect(versions.length).to eq(1)
+    end
+
     it 'should burst host cache' do
       group.add_user(user.id)
 


### PR DESCRIPTION
When a user is removed from the group using method delete_all, it will skip the callback method (https://guides.rubyonrails.org/active_record_callbacks.html#skipping-callbacks).
Paper trail only created when the callback is called, this is why the delete_all method will not create a paper trail record.